### PR TITLE
fix: disabled pop modal when array is empty

### DIFF
--- a/src/pages/InvestNew/Withdraw/index.jsx
+++ b/src/pages/InvestNew/Withdraw/index.jsx
@@ -187,8 +187,10 @@ export default function Withdraw({
       })
     ).then(array => {
       const nextBurnTokens = compact(array)
-      setIsShowZipModal(true)
-      setBurnTokens(nextBurnTokens)
+      if (!isEmpty(nextBurnTokens)) {
+        setIsShowZipModal(true)
+        setBurnTokens(nextBurnTokens)
+      }
     })
   }
 


### PR DESCRIPTION
# Description
1. bug fixed

# Ticket
http://192.168.60.40:8080/browse/BOC-1666

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
